### PR TITLE
Added missed lines of class.mfct.non-static example

### DIFF
--- a/all_section.md
+++ b/all_section.md
@@ -536,6 +536,11 @@ enclosing object of type D. Otherwise, the behavior is undefined.
   int f(X*x) {
     return x->f();
   }
+
+  int main() {
+    A a;
+    std::cout<< f(reinterpret_cast<X*>(&a));
+  }
   ```
   - [Examples live](https://godbolt.org/z/0zBLzy)
   


### PR DESCRIPTION
A couple of important lines are missing in one of the examples (probably don't need the `std::cout<<` part but added it as it was the part of the godbolt code). Feel free to edit